### PR TITLE
dont mix dtypes

### DIFF
--- a/2024/22.py
+++ b/2024/22.py
@@ -4,11 +4,11 @@ import numpy as np
 def day22():
     data = [int(line) for line in aocd.get_data(day=22, year=2024).splitlines()]
     UNIQUE_SEQUENCES = 19**4
-    npa = np.array(data)
+    npa = np.array(data, dtype=np.uint32)
     prev = npa%10
     base = [prev]
     cv = []
-    col = np.zeros(UNIQUE_SEQUENCES, dtype=np.uint16)
+    col = np.zeros(UNIQUE_SEQUENCES, dtype=np.uint32)
     
     for i in range(2000):
         npa ^= (npa << 6) & 16777215


### PR DESCRIPTION
Before:

```
$ time python3 2024/22.py
part1: 20071921341 part2: 2236
python3 2024/22.py  0.76s user 0.05s system 99% cpu 0.817 total
```

After:

```
$ time python3 2024/22.py
part1: 20071921341 part2: 2236
python3 2024/22.py  0.49s user 0.04s system 98% cpu 0.534 total
```

(CPython 3.13.1 on a macbook air)